### PR TITLE
Better logging for cache fields command

### DIFF
--- a/src/Console/CacheFields.php
+++ b/src/Console/CacheFields.php
@@ -12,13 +12,16 @@ class CacheFields extends AbstractCommand
     {
         $components = offbeat('components')->get();
         $fields = [];
+        $amount = 0;
 
         if (!empty($components)) foreach ($components as $component) {
             $componentClassName = explode('\\', $component);
             $componentClassName = array_pop($componentClassName);
-    
+
             if ($component::supports('pagebuilder')) {
                 $fieldsMapper = new FieldsMapper($component::getForm(), lcfirst($componentClassName));
+                $amount++;
+                $this->log("Caching component #$amount $componentClassName");
 
                 $componentFields = $fieldsMapper->map();
 
@@ -30,6 +33,6 @@ class CacheFields extends AbstractCommand
 
         update_option('acf_layout_builder_component_fields', $fields);
 
-        $this->success('Components fields cached');
+        $this->success("Components fields cached for $amount components");
     }
 }


### PR DESCRIPTION

With this change the output of **acf-layout:cache-fields** will look like this:
> ...
> Caching component #95 CurrencyTableWorld
> Caching component #96 CurrencyTile
> Caching component #97 CurrencyTopFlops
> Caching component #98 DownloadForm
> Caching component #99 FeeCalculator
> Success: Components fields cached for 99 components

Handy to figure out why a specific component got stuck loading or failed. 
 